### PR TITLE
Support for Mini-XML 3.0

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -27,38 +27,41 @@ get_value(mxml_node_t *node,		/* I - Node to get */
 	*end;							/* End of buffer */
 	int			len;				/* Length of node */
 	mxml_node_t	*current;			/* Current node */
+	const char	*text;				/* Current node text */
+	int			whitespace;			/* Current node whitespace indicator */
     
     
 	ptr = (char*)buffer;
 	end = (char*)buffer + buflen - 1;
 	char tempbuf[4092];
-	current = node->child;
-	for (current = node->child; current && ptr < end; current = current->next)
+	for (current = mxmlGetFirstChild(node); current && ptr < end; current = mxmlGetNextSibling(current))
 	{
-		if (current->type == MXML_TEXT)
+		if (mxmlGetType(current) == MXML_TEXT)
 		{
-			if (current->value.text.whitespace)
+			text = mxmlGetText(current, &whitespace);
+
+			if (whitespace != 0)
 				*ptr++ = ' ';
 
-			len = (int)strlen(current->value.text.string);
+			len = (int)strlen(text);
 			if (len > (int)(end - ptr))
 				len = (int)(end - ptr);
 
-			memcpy(ptr, current->value.text.string, len);
+			memcpy(ptr, text, len);
 			ptr += len;
 		}
-		else if (current->type == MXML_OPAQUE)
+		else if (mxmlGetType(current) == MXML_OPAQUE)
 		{
-			len = (int)strlen(current->value.opaque);
+			len = (int)strlen(mxmlGetOpaque(current));
 			if (len > (int)(end - ptr))
 				len = (int)(end - ptr);
 
-			memcpy(ptr, current->value.opaque, len);
+			memcpy(ptr, mxmlGetOpaque(current), len);
 			ptr += len;
 		}
-		else if (current->type == MXML_INTEGER)
+		else if (mxmlGetType(current) == MXML_INTEGER)
 		{
-			sprintf(tempbuf, "%d", current->value.integer);
+			sprintf(tempbuf, "%d", mxmlGetInteger(current));
 			len = (int)strlen(tempbuf);
 			if (len > (int)(end - ptr))
 				len = (int)(end - ptr);
@@ -66,9 +69,9 @@ get_value(mxml_node_t *node,		/* I - Node to get */
 			memcpy(ptr, tempbuf, len);
 			ptr += len;
 		}
-		else if (current->type == MXML_REAL)
+		else if (mxmlGetType(current) == MXML_REAL)
 		{
-			sprintf(tempbuf, "%f", current->value.real);
+			sprintf(tempbuf, "%f", mxmlGetReal(current));
 			len = (int)strlen(tempbuf);
 			if (len > (int)(end - ptr))
 				len = (int)(end - ptr);
@@ -84,7 +87,7 @@ get_value(mxml_node_t *node,		/* I - Node to get */
 const char *whitespace_cb(mxml_node_t *node, int where)
 {
 	/* code by Matt_P */
-	const char *name = node->value.element.name;
+	const char *name = mxmlGetElement(node);
 	mxml_node_t * temp = node;
 	char tab_buffer[25];
 	memset( tab_buffer , 0 , 15 );
@@ -92,11 +95,11 @@ const char *whitespace_cb(mxml_node_t *node, int where)
 	while(temp){
 		depth++;
 		tab_buffer[depth - 1] = '\t';
-		temp = temp->parent;
+		temp = mxmlGetParent(temp);
 	}
 	if (where == 3 || where == 1){
 		return "";
-	}else if(((node->prev && where == 0) || node->parent) && !(where == 2 && strcmp(name, "rotate") && strcmp(name, "scale") && strcmp(name, "translate") && strcmp(name, "xmlyt") && strcmp(name, "xmlan") && strcmp(name, "pai1") && strcmp(name, "pat1") && strcmp(name, "pah1") && strcmp(name, "seconds") && strcmp(name, "entries") && strcmp(name, "triplet") && strcmp(name, "pair") && strcmp(name, "entry") && strcmp(name, "pane") && (strcmp(name, "tag") && strcmp(name, "size") && strcmp(name, "material") && strcmp(name, "vtx") && strcmp(name, "colors") && strcmp(name, "subs") && strcmp(name, "usdentry") && strcmp(name, "font") && strcmp(name, "wnd4") && strcmp(name, "wnd4mat") && strcmp(name, "set") && strcmp(name, "coordinates") && strcmp(name, "TevStage") && strcmp(name, "texture") && strcmp(name, "TextureSRT") && strcmp(name, "CoordGen") && strcmp(name, "ChanControl") && strcmp(name, "MaterialColor") && strcmp(name, "TevSwapModeTable") && strcmp(name, "IndTextureSRT") && strcmp(name, "IndTextureOrder") && strcmp(name, "AlphaCompare") && strcmp(name, "BlendMode") )) ){
+	}else if(((mxmlGetPrevSibling(node) && where == 0) || mxmlGetParent(node)) && !(where == 2 && strcmp(name, "rotate") && strcmp(name, "scale") && strcmp(name, "translate") && strcmp(name, "xmlyt") && strcmp(name, "xmlan") && strcmp(name, "pai1") && strcmp(name, "pat1") && strcmp(name, "pah1") && strcmp(name, "seconds") && strcmp(name, "entries") && strcmp(name, "triplet") && strcmp(name, "pair") && strcmp(name, "entry") && strcmp(name, "pane") && (strcmp(name, "tag") && strcmp(name, "size") && strcmp(name, "material") && strcmp(name, "vtx") && strcmp(name, "colors") && strcmp(name, "subs") && strcmp(name, "usdentry") && strcmp(name, "font") && strcmp(name, "wnd4") && strcmp(name, "wnd4mat") && strcmp(name, "set") && strcmp(name, "coordinates") && strcmp(name, "TevStage") && strcmp(name, "texture") && strcmp(name, "TextureSRT") && strcmp(name, "CoordGen") && strcmp(name, "ChanControl") && strcmp(name, "MaterialColor") && strcmp(name, "TevSwapModeTable") && strcmp(name, "IndTextureSRT") && strcmp(name, "IndTextureOrder") && strcmp(name, "AlphaCompare") && strcmp(name, "BlendMode") )) ){
 		sprintf( xmlbuff , "\n%s" , tab_buffer );
 	}else{
 		return "";


### PR DESCRIPTION
[Mini-XML (libmxml) 3.0, which released March 2, 2019,](https://www.msweet.org/blog/2019-03-02-mxml-3.0.html) made some struct definitions private, requiring client code to use the official public API instead.

The required changes are pretty simple -- just replacing `mxml_node_t` member accesses with calls to getter functions.